### PR TITLE
[Fix] UnityEditor 빌드 시 포함 안 되게

### DIFF
--- a/End Distopirism/Assets/Scripts/BattleManager.cs
+++ b/End Distopirism/Assets/Scripts/BattleManager.cs
@@ -1,7 +1,6 @@
 using System.Collections;
 using System.Collections.Generic;
 using Unity.VisualScripting;
-using UnityEditor.Timeline.Actions;
 using UnityEngine;
 
 public enum GameState

--- a/End Distopirism/Assets/Scripts/CharacterInspectorEditor.cs
+++ b/End Distopirism/Assets/Scripts/CharacterInspectorEditor.cs
@@ -1,3 +1,4 @@
+#if UNITY_EDITOR
 using UnityEditor;
 using UnityEngine;
 
@@ -86,3 +87,5 @@ public class CharacterInspectorEditor : Editor
         }
     }
 }
+
+#endif // UNITY_EDITOR


### PR DESCRIPTION
## 수정

에디터 환경에서만 Editor 스크립트 빌드되게 수정.

## 이유

`UnityEditor` 네임스페이스는 빌드할 때 포함 안 되기 때문에 분기 처리 해야함.