### PR TITLE
[Feat] 코인 관련 스크립트 분리

### DIFF
--- a/End Distopirism/Assets/Scripts/Player.meta
+++ b/End Distopirism/Assets/Scripts/Player.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1fa8445f470a58b9fb3f0e1f6be6aa45
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/End Distopirism/Assets/Scripts/Player/Coin.meta
+++ b/End Distopirism/Assets/Scripts/Player/Coin.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2b811497a30654484bb8d2f83fca1feb
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/End Distopirism/Assets/Scripts/Player/Coin/CoinBase.cs
+++ b/End Distopirism/Assets/Scripts/Player/Coin/CoinBase.cs
@@ -1,0 +1,49 @@
+using UnityEngine;
+
+public class CoinBase : MonoBehaviour, IBattleCoin
+{
+    public int maxCoin;
+
+    [field: SerializeField]
+    [field: Header("보유하고 있는 코인")]
+    public int Coin { get; private set; }
+
+    // FIXME: 여기에 존재하면 안 됨.
+    //        별도로 정신력 관련 클레스 생성
+    private float maxMentality = 100.0f;
+    
+    private const float MAX_PROBABILITY = 60.0f;
+
+    private void Start()
+    {
+        Coin = maxCoin;
+    }
+
+    public void AddCoin(int amount)
+    {
+        Coin += amount;
+    }
+
+    public int CoinRoll(int rerollCount, float mentality)
+    {
+        int successCount = 0;
+
+        for (int i = 0; i < rerollCount; ++i)
+        {
+            float currentProbability = Mathf.Max(0.0f, MAX_PROBABILITY * (mentality / maxMentality));
+
+            for (int j = 0; j < Coin - 1; ++j)
+            {
+                if (currentProbability > Random.value)
+                {
+                    Debug.Log($"{gameObject.name} > Coin throw success count:({successCount}) Coin count:({Coin})");
+                    ++successCount;
+                }
+            }
+        }
+
+        return successCount;
+    }
+
+    public bool IsCoinLeft() => Coin > 0;
+}

--- a/End Distopirism/Assets/Scripts/Player/Coin/CoinBase.cs.meta
+++ b/End Distopirism/Assets/Scripts/Player/Coin/CoinBase.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 717b40fcd7a5fe06fbf0e73871dbbd0b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/End Distopirism/Assets/Scripts/Player/Interface.meta
+++ b/End Distopirism/Assets/Scripts/Player/Interface.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4181d8a5a8d9ba047916bd33eb1558e5
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/End Distopirism/Assets/Scripts/Player/Interface/IBattleCoin.cs
+++ b/End Distopirism/Assets/Scripts/Player/Interface/IBattleCoin.cs
@@ -1,0 +1,25 @@
+/// <summary>
+/// 플레이어 코인 관련 인터페이스
+/// </summary>
+interface IBattleCoin
+{
+    /// <summary>
+    /// 코인이 남아 있는지 확인
+    /// </summary>
+    /// <returns>코인이 0보다 크다면 True</returns>
+    public bool IsCoinLeft();
+
+    /// <summary>
+    /// 코인 리롤
+    /// </summary>
+    /// <param name="rerollCount">리롤 횟수</param>
+    /// <param name="mentality"정신력</param>
+    /// <returns>코인 리롤 성공 횟수</returns>
+    public int CoinRoll(int rerollCount, float mentality);
+
+    /// <summary>
+    /// 코인을 더함
+    /// </summary>
+    /// <param name="amount">더할 코인 수</param>
+    public void AddCoin(int amount);
+}

--- a/End Distopirism/Assets/Scripts/Player/Interface/IBattleCoin.cs.meta
+++ b/End Distopirism/Assets/Scripts/Player/Interface/IBattleCoin.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2cfaafc6a1821a0708a2c989c0090ece
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## 수정

코인 관련 기능 분리.
1. `BattleManager.cs` 에 있던 코인 리롤 관련 기능을 `CoinBase.cs` 로 이동하고, 기타 유틸을 조금 추가함.
2. `IBattleCoin` 인터페이스를 생성함.

기존 코드를 수정하는 작업은 진행하지 않음.

## 이유

`BattleManager.cs` 에서 너무나 많은 일을 하고 있음.
코인 관련 기능은 배틀보다 플레이어와 더 가까운 기능인 듯 함.

한국어로 하면, `배틀 메니저의 코인 리롤 => 플레이어의 코인 리롤` 으로 풀어짐.

### 코드를 분리한 이유

`BattleManager.cs` 에서 이미 잘 동작하는 기능이고, 딱히 버그도 없는데 왜 수정하나면,
앞으로 두달 더 진행해 나가야 하는 프로젝트이고, 배틀이 주 컨텐츠가 될 것 같다고 생각함.

그렇게 되면 `BattleManager.cs` 를 계속 수정해 나가는 작업이 이루어 질 것임.
나중에 가면 손쓸 수 없이 코드의 크기와 길이가 길어지고, 여기저기서 `BattleManager.cs` 를 의존하게 됨.

코인 리롤 로직만 해당되는 것이 아니라, 데미지 로직, 공격 로직 등, `배틀 메니저` 의 `무엇무엇` 보다는,
별도의 클레스에서 진행하는 것이 더욱 직관적일 것임.

~~꼬우면 김현태 통해서 연락하거나 아래에 코멘트 다십시오 휴먼~~
